### PR TITLE
Use global ssm parameter for DD keys

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 locals {
-  secret_names = concat(var.secret_names, [
+  global_secrets = concat(var.secret_names, [
     "DD_API_KEY",
   ])
 
@@ -119,5 +119,5 @@ module "ssm" {
   version  = "~> 1.0"
   env      = var.env
   app_name = "global"
-  names    = var.enabled ? local.secret_names : []
+  names    = var.enabled ? local.global_secrets : []
 }

--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,6 @@ module "ssm" {
   source   = "hazelops/ssm-secrets/aws"
   version  = "~> 1.0"
   env      = var.env
-  app_name = var.app_name
+  app_name = "global"
   names    = var.enabled ? local.secret_names : []
 }


### PR DESCRIPTION
- Since we want to keep DD secrets under `/env/global/*` path - this is simple, working change

- [Optional] We also can rename `var.secret_names` to `var.global_secrets` but it can affect any existing TF configuration. @AutomationD Thoughts?