### PR TITLE
Use public.ecr.aws registry for the default datadog-agent image

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "secret_names" {
 
 variable "docker_image_name" {
   type    = string
-  default = "datadog/agent"
+  default = "public.ecr.aws/datadog/agent"
 }
 
 variable "docker_image_tag" {


### PR DESCRIPTION
Using public.erc.aws registry provides a better integration on the
AWS ECS environment:
* reduce network cost
* better availability
