### PR TITLE
Map both 8125 and 8126 ports

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,12 +79,7 @@ locals {
     )
 
 
-    portMappings = var.ecs_launch_type == "FARGATE" ? [
-      {
-        protocol      = "udp",
-        containerPort = 8125
-      }
-      ] : [
+    portMappings = [
       {
         protocol      = "tcp",
         containerPort = 8126


### PR DESCRIPTION
With Fargate monitoring we want to send traces as well, we can't if the port is not mapped.